### PR TITLE
remove boxshadow from menu to work with firefox

### DIFF
--- a/app/assets/stylesheets/layout/_menu.scss
+++ b/app/assets/stylesheets/layout/_menu.scss
@@ -23,11 +23,6 @@ a{
 
 }
 
-%goo{
-  filter:url('#shadowed-goo');
-  // debug
-  //background:rgba(255,0,0,0.2);
-}
 %ball{
   background:$fg;
   border-radius:100%;
@@ -84,7 +79,6 @@ $hamburger-spacing:8px;
   }
 }
 .menu{
-  @extend %goo;
   $width:650px;
   $height:150px;
   position: absolute;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
 
   <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
+
   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
 
   <%= csrf_meta_tags %>


### PR DESCRIPTION
i had to remove boxshadow from menu in order for the menu to show up on firefox 
